### PR TITLE
Add api endpoint for search

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -6,7 +6,7 @@ const mongoose = require('mongoose');
 const indexRouter = require('./routes/index');
 
 
-mongoose.connect(process.env.MONGO_URI, { useNewUrlParser: true, useUnifiedTopology: true }).then(() => {
+mongoose.connect(process.env.MONGO_URI, { useNewUrlParser: true, useUnifiedTopology: true, dbName: 'Medshare' }).then(() => {
   console.log("connected to mongo");
 }).catch((e) => {
   console.log(e);

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,9 +1,25 @@
 var express = require('express');
 var router = express.Router();
+const mongoose = require('mongoose');
+
+const Product = mongoose.connection.model('Product', {}, 'Product');
 
 /* GET home page. */
 router.get('/', function(req, res, next) {
-  res.send("this is an API route");
+  res.send("this is the home API route");
+});
+
+/* GET search from query */
+router.get('/search', (req, res, next) => {
+  const q = req.query.q;
+  const query_fuzzy = {$regex: new RegExp(q, 'i')};
+  Product.find().or([{ProductName: query_fuzzy}, {'Category Name': query_fuzzy}, {'Sub Category': query_fuzzy}])
+      .then(products => {
+        return res.send(products);
+      })
+      .catch(err => {
+        return next(err);
+      })
 });
 
 module.exports = router;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -15,7 +15,7 @@ router.get('/search', async (req, res, next) => {
   const query_fuzzy = {$regex: new RegExp(q, 'i')};
   let products = null;
   try {
-    products = await Product.find().or([{ProductName: query_fuzzy}, {'Category Name': query_fuzzy}, {'Sub Category': query_fuzzy}]);
+    products = await Product.find().or([{ProductName: query_fuzzy}, {'Category Name': query_fuzzy}, {'Sub Category': query_fuzzy}, {ProductRef: query_fuzzy}]);
   } catch (err) {
     return res.status(500).send(err);
   }

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -10,16 +10,16 @@ router.get('/', function(req, res, next) {
 });
 
 /* GET search from query */
-router.get('/search', (req, res, next) => {
+router.get('/search', async (req, res, next) => {
   const q = req.query.q;
   const query_fuzzy = {$regex: new RegExp(q, 'i')};
-  Product.find().or([{ProductName: query_fuzzy}, {'Category Name': query_fuzzy}, {'Sub Category': query_fuzzy}])
-      .then(products => {
-        return res.send(products);
-      })
-      .catch(err => {
-        return next(err);
-      })
+  let products = null;
+  try {
+    products = await Product.find().or([{ProductName: query_fuzzy}, {'Category Name': query_fuzzy}, {'Sub Category': query_fuzzy}]);
+  } catch (err) {
+    return res.status(500).send(err);
+  }
+  res.send(products);
 });
 
 module.exports = router;


### PR DESCRIPTION
This pr adds an API endpoint for the search engine: `/api/search/`

Issue: close #6 close #7 

Based on the query given, it fuzzy matches (case insensitive and contains the query word in the product metadata) to any one of the `ProductName`, `Category Name`, `Sub Category`, or `ProductRef`.

It returns as an array of JSONs in the order of whatever mongo returns.

e2e:
query: `medical`
<img width="614" alt="Screen Shot 2019-10-01 at 6 22 02 PM" src="https://user-images.githubusercontent.com/12789302/66005302-fdfdfc00-e478-11e9-83f3-b739fde0c1b6.png">

query: `700019`
<img width="643" alt="Screen Shot 2019-10-02 at 1 46 00 PM" src="https://user-images.githubusercontent.com/12789302/66068167-17578480-e51b-11e9-820a-f046477945e6.png">

