### PR TITLE
Autocomplete with ProductCount

### DIFF
--- a/server/controllers/searchController.js
+++ b/server/controllers/searchController.js
@@ -28,29 +28,26 @@ searchController.fuzzyQueryProducts = async queries => {
     });
 };
 
-searchController.autocompleteTerms = (products, q, numOfTerms = 7) => {
-  const query = q.toLowerCase();
-  const counter = {};
-  // eslint-disable-next-line no-useless-escape, prettier/prettier
-  const separators = new RegExp([' ', '/', '-', '&', '\\\*', '"', ',', '\\\\'].join('|'), 'g');
+/*
+  Get all words from ProductCoutn that starts with the given query
+  Sorted by the number of the times the word occurs
 
-  products.forEach(product => {
-    fieldsOfInterest.forEach(field => {
-      const valueString = JSON.stringify(product.toObject()[field]);
-      valueString.split(separators).forEach(word => {
-        const formattedWord = word.trim().toLowerCase();
-        if (formattedWord.toLowerCase().startsWith(query)) {
-          counter[formattedWord] = (counter[formattedWord] || 0) + 1;
-        }
-      });
-    });
-  });
-  const counterArray = Object.entries(counter);
-  counterArray.sort((a, b) => {
-    return b[1] - a[1];
-  });
+  Arg:
+    q (str): prefix query word
+    numOfTerms (optional): number of results to be returned
 
-  return counterArray.slice(0, numOfTerms).map(word => word[0]);
+  Returns:
+    array of top n possible terms
+ */
+searchController.autocompleteTerms = async (q, numOfTerms = 7) => {
+  const query = q.trim().toLowerCase();
+
+  const wordCounts = await ProductCount.find({
+    Word: { $regex: new RegExp(`^${query}`) },
+  })
+    .sort({ Count: -1 })
+    .limit(numOfTerms);
+  return wordCounts;
 };
 
 /*

--- a/server/controllers/searchController.js
+++ b/server/controllers/searchController.js
@@ -1,0 +1,55 @@
+const mongoose = require('mongoose');
+
+const Product = mongoose.connection.model('Product', {}, 'Product');
+
+const searchController = {};
+
+const fieldsOfInterest = [
+  'ProductName',
+  'CategoryName',
+  'SubCategory',
+  'ProductRef',
+];
+
+searchController.fuzzyQueryProducts = async queries => {
+  const searchQuery = fieldsOfInterest.map(field => {
+    return {
+      $and: queries.map(query => {
+        return { [field]: { $regex: new RegExp(query, 'i') } };
+      }),
+    };
+  });
+
+  return Product.find()
+    .or(searchQuery)
+    .then(products => {
+      return products;
+    });
+};
+
+searchController.autocompleteTerms = (products, q, numOfTerms = 7) => {
+  const query = q.toLowerCase();
+  const counter = {};
+  // eslint-disable-next-line no-useless-escape, prettier/prettier
+  const separators = new RegExp([' ', '/', '-', '&', '\\\*', '"', ',', '\\\\'].join('|'), 'g');
+
+  products.forEach(product => {
+    fieldsOfInterest.forEach(field => {
+      const valueString = JSON.stringify(product.toObject()[field]);
+      valueString.split(separators).forEach(word => {
+        const formattedWord = word.trim().toLowerCase();
+        if (formattedWord.toLowerCase().startsWith(query)) {
+          counter[formattedWord] = (counter[formattedWord] || 0) + 1;
+        }
+      });
+    });
+  });
+  const counterArray = Object.entries(counter);
+  counterArray.sort((a, b) => {
+    return b[1] - a[1];
+  });
+
+  return counterArray.slice(0, numOfTerms).map(word => word[0]);
+};
+
+module.exports = searchController;

--- a/server/controllers/searchController.js
+++ b/server/controllers/searchController.js
@@ -1,6 +1,7 @@
 const mongoose = require('mongoose');
 
 const Product = mongoose.connection.model('Product', {}, 'Product');
+const ProductCount = require('../models/ProductCount');
 
 const searchController = {};
 
@@ -50,6 +51,48 @@ searchController.autocompleteTerms = (products, q, numOfTerms = 7) => {
   });
 
   return counterArray.slice(0, numOfTerms).map(word => word[0]);
+};
+
+/*
+  Resets the ProductCount collections
+  1) deletes everything in ProductCount
+  2) fetches everything from Product collections
+  3) parses all the words and keeps count of each word
+  4) saves the word counts to ProductCount
+
+  This ensures correct word count metadata between Product and ProductCount
+ */
+searchController.resetProductCount = async () => {
+  await ProductCount.deleteMany({});
+  const counter = {};
+  // eslint-disable-next-line no-useless-escape, prettier/prettier
+  const separators = new RegExp([' ', '/', '-', '&', '\\\*', '"', ',', '\\\\'].join('|'), 'g');
+
+  // finds all products
+  const products = await Product.find();
+
+  products.forEach(product => {
+    fieldsOfInterest.forEach(field => {
+      const valueString = JSON.stringify(product.toObject()[field]);
+      valueString.split(separators).forEach(word => {
+        const formattedWord = word.trim().toLowerCase();
+        counter[formattedWord] = (counter[formattedWord] || 0) + 1;
+      });
+    });
+  });
+
+  const productCountArray = Object.entries(counter).map(([word, count]) => {
+    return new ProductCount({
+      Word: word,
+      Count: count,
+    });
+  });
+
+  return ProductCount.insertMany(productCountArray, { ordered: false }).then(
+    docs => {
+      return docs;
+    },
+  );
 };
 
 module.exports = searchController;

--- a/server/models/ProductCount.js
+++ b/server/models/ProductCount.js
@@ -1,0 +1,9 @@
+const MONGOOSE = require('mongoose');
+
+const productCountSchema = new MONGOOSE.Schema({
+  Word: { type: String, required: true },
+  Count: { type: Number, required: true },
+});
+
+const ProductCount = MONGOOSE.model('ProductCount', productCountSchema);
+module.exports = ProductCount;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,30 +1,55 @@
 const express = require('express');
-const mongoose = require('mongoose');
+const searchController = require('../controllers/searchController');
 
 const router = express.Router();
-const Product = mongoose.connection.model('Product', {}, 'Product');
 
 /* GET home page. */
 router.get('/', (req, res) => {
   res.send('this is an API route');
 });
 
-/* GET search from query */
+/*
+  GET search based on query
+
+  checks to see if query word matches any of the attributes in Product
+  more specifically ProductName, Category Name, Sub Category, ProductRef
+
+  Args:
+    q (str): query key word
+
+  Returns:
+    array of all matching products
+ */
 router.get('/search', async (req, res) => {
   const { q } = req.query;
-  const queryFuzzy = { $regex: new RegExp(q, 'i') };
-  let products = null;
+  const queries = q.split(' ');
   try {
-    products = await Product.find().or([
-      { ProductName: queryFuzzy },
-      { 'Category Name': queryFuzzy },
-      { 'Sub Category': queryFuzzy },
-      { ProductRef: queryFuzzy },
-    ]);
+    const products = await searchController.fuzzyQueryProducts(queries);
+    return res.send(products);
   } catch (err) {
     return res.status(500).send(err);
   }
-  return res.send(products);
+});
+
+/*
+  GET autocomplete search based on prefix
+
+  Args:
+    q (str): prefix query word
+
+  Returns:
+    array of top 7 possible terms
+ */
+router.get('/autocomplete', async (req, res) => {
+  const { q } = req.query;
+  const query = q.split(' ').pop();
+  try {
+    const products = await searchController.fuzzyQueryProducts([query]);
+    const completes = searchController.autocompleteTerms(products, q);
+    return res.send(completes);
+  } catch (err) {
+    return res.status(500).send(err);
+  }
 });
 
 module.exports = router;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -22,6 +22,9 @@ router.get('/', (req, res) => {
  */
 router.get('/search', async (req, res) => {
   const { q } = req.query;
+  if (q === null || typeof q !== 'string') {
+    return res.status(400).send('Query word must exist!');
+  }
   const queries = q.split(' ');
   try {
     const products = await searchController.fuzzyQueryProducts(queries);
@@ -42,10 +45,12 @@ router.get('/search', async (req, res) => {
  */
 router.get('/autocomplete', async (req, res) => {
   const { q } = req.query;
+  if (q === null || typeof q !== 'string') {
+    return res.status(400).send('Query word must exist!');
+  }
   const query = q.split(' ').pop();
   try {
-    const products = await searchController.fuzzyQueryProducts([query]);
-    const completes = searchController.autocompleteTerms(products, q);
+    const completes = await searchController.autocompleteTerms(query);
     return res.send(completes);
   } catch (err) {
     return res.status(500).send(err);


### PR DESCRIPTION
# This pr introduces the following:

- `ProductCount` collection in the db.
  - It keeps track of the number of occurrences  of all the words in `Product`. It allows more efficient implementation of autocomplete. All searches take less than ~100ms, while previously some queries took more than 5 seconds.
- Autocomplete implementation
  - Given a prefix of a word, it returns top 7 possible word completions. For example, given "me", it could return "medical", "med", "medicine", etc...
- Multi word search
  - Given multiple words, it returns results that have all the key words in a product. Previously, it searched as one large chunk of a keyword. For example, "large box" previous searched for "large box" as one keyword, while here we return results that have both "large" and "box" in a `Product` but it could be in any order (e.g. "large medical box" or "box with large gloves")

### Issue: closes #21 

## e2e

Query: "med"
<img width="1280" alt="Screen Shot 2019-10-12 at 5 59 16 PM" src="https://user-images.githubusercontent.com/12789302/66708267-d8e07780-ed1b-11e9-8b2c-0a2c90f20f6c.png">

---- 
Query: ""
<img width="1282" alt="Screen Shot 2019-10-12 at 5 59 31 PM" src="https://user-images.githubusercontent.com/12789302/66708266-d8e07780-ed1b-11e9-8433-525aaed2a39a.png">

---- 
No query given
<img width="1275" alt="Screen Shot 2019-10-12 at 5 59 46 PM" src="https://user-images.githubusercontent.com/12789302/66708265-d8e07780-ed1b-11e9-879f-2b6ebee73169.png">

