### PR TITLE
Feature sorting improvement

### DIFF
--- a/backend/src/api/search.js
+++ b/backend/src/api/search.js
@@ -17,25 +17,35 @@ const searchController = require('../controllers/searchController');
   Returns:
     array of all matching products
  */
-router.get('/', ensureParameterInRequest('q', 'string'), ensureParameterInRequest('q', 'string'), async (req, res) => {
-  const { q, subcategories, category, features } = req.query;
+router.get(
+  '/',
+  ensureParameterInRequest('q', 'string'),
+  ensureParameterInRequest('features', 'string'),
+  async (req, res) => {
+    const { q, subcategories, category, features } = req.query;
 
-  try {
-    const queries = processArrayParameterAndNormalize(q, ' ', false);
-    const featuresArray = processArrayParameterAndNormalize(features, ',', false);
-    let normalizedCategory = category;
-    if (category) {
-      normalizedCategory = category.toLowerCase();
+    try {
+      const queries = processArrayParameterAndNormalize(q, ' ', false);
+      const featuresArray = processArrayParameterAndNormalize(features, ',', false);
+      let normalizedCategory = category;
+      if (category) {
+        normalizedCategory = category.toLowerCase();
+      }
+
+      const subcategoriesArr = processArrayParameterAndNormalize(subcategories, ',', true);
+      const products = await searchController.queryProducts(
+        queries,
+        normalizedCategory,
+        subcategoriesArr,
+        featuresArray
+      );
+      return res.send(products);
+    } catch (err) {
+      console.log(err);
+      return res.status(500).send(err.message);
     }
-
-    const subcategoriesArr = processArrayParameterAndNormalize(subcategories, ',', true);
-    const products = await searchController.queryProducts(queries, normalizedCategory, subcategoriesArr, featuresArray);
-    return res.send(products);
-  } catch (err) {
-    console.log(err);
-    return res.status(500).send(err.message);
   }
-});
+);
 
 /*
   GET autocomplete endpoint

--- a/backend/src/controllers/searchController.js
+++ b/backend/src/controllers/searchController.js
@@ -1,9 +1,10 @@
 const { ObjectId } = require('mongoose').Types;
-const Product = require('../database/models/Product');
+const { Product, ProductFeatures } = require('../database/models');
 
 const searchController = {};
 
 const PAGE_SIZE = 15;
+const DIFF_FIELD = 'POSITION_DIFF';
 
 searchController.queryFeaturesByProducts = async (
   nameFilter,
@@ -12,6 +13,8 @@ searchController.queryFeaturesByProducts = async (
   filterFeatureIds
 ) => {
   const filterFeatureMongooseIds = filterFeatureIds.map(ObjectId);
+  const inputFeatures = await ProductFeatures.getFeaturesByIds(filterFeatureMongooseIds);
+  const targetFeaturePosition = getTotalLengthOfFeatures(inputFeatures);
   const filter = generateProductFilterWithRequiredFeatures(
     nameFilter,
     filterCategory,
@@ -28,19 +31,12 @@ searchController.queryFeaturesByProducts = async (
       $regex: new RegExp(nameFilter, 'i')
     }
   };
-  return Product.aggregate()
-    .match(filter)
-    .unwind('features')
-    .replaceRoot('features')
-    .match(featureInQueryFilter)
-    .group({ _id: '$productFeature' })
-    .lookup({ from: 'productfeatures', localField: '_id', foreignField: '_id', as: 'productFeature' })
-    .unwind('productFeature')
-    .replaceRoot('productFeature')
-    .match(featureNameFilter)
-    .sort({ count: -1 })
-    .limit(PAGE_SIZE);
+  return aggregateProductFeaturesFromProducts(filter, featureInQueryFilter, featureNameFilter, targetFeaturePosition);
 };
+
+function getTotalLengthOfFeatures(features) {
+  return features.map(feature => feature.name.length).reduce((left, right) => left + right, 0);
+}
 
 searchController.queryProducts = async (productNameFilter, filterCategory, filterSubcategories, filterFeatureIds) => {
   const filterFeatureMongooseIds = filterFeatureIds.map(ObjectId);
@@ -104,8 +100,40 @@ function addProductFeatureFilter(filter, requiredFeatureIds) {
   return filter;
 }
 
+/**
+ * Generates base productFeature filter for filtering through product id's in products
+ * @param featureId
+ * @returns {{productFeature: {$eq: *}}}
+ */
 function generateBaseProductFeatureFilter(featureId) {
   return { productFeature: { $eq: featureId } };
+}
+
+/**
+ *
+ * @param productFilter - what to filter the products on
+ * @param productFeatureFilter - what to filter the features in the products on (not the entire feature documents;
+ * the nested feature metadata
+ * @param featureFilter - what to filter the entire feature documents on
+ * @param targetPosition - the "target" position of the output features. Features will be returned in
+ * order of how close they are to this target position
+ * @returns {*|Aggregate}
+ */
+function aggregateProductFeaturesFromProducts(productFilter, productFeatureFilter, featureFilter, targetPosition) {
+  return Product.aggregate()
+    .match(productFilter)
+    .unwind('features')
+    .replaceRoot('features')
+    .match(productFeatureFilter)
+    .addFields({ [DIFF_FIELD]: { $abs: { $subtract: ['$name.medianIndex', targetPosition] } } }) // calculate the diff from the target position
+    .group({ _id: '$productFeature', [DIFF_FIELD]: { $min: '$' + DIFF_FIELD } }) // group matching product features. keep the one with the lowest delta
+    .lookup({ from: 'productfeatures', localField: '_id', foreignField: '_id', as: 'productFeature' })
+    .unwind('productFeature')
+    .replaceRoot({ $mergeObjects: ['$productFeature', '$$ROOT'] }) // merge the root with the productFeature object because we want to keep the DIFF_FIELD (and maybe other calculated fields in the future)
+    .project({ productFeature: 0 }) // it's attributes go merged in, remove it
+    .match(featureFilter)
+    .sort({ [DIFF_FIELD]: 1, count: -1 }) // sort by position diff
+    .limit(PAGE_SIZE);
 }
 
 module.exports = searchController;

--- a/backend/src/database/models/ProductFeatures.js
+++ b/backend/src/database/models/ProductFeatures.js
@@ -9,6 +9,26 @@ const productFeaturesSchema = new mongoose.Schema({
   count: { type: Number, required: true }
 });
 
+/**
+ * Gets ProductFeatures that have have an id in the input list
+ * @param featureIds - of type MongooseId
+ * @returns {Promise<ProductFeature>}
+ */
+productFeaturesSchema.statics.getFeaturesByIds = async function(featureIds) {
+  return this.find(generateIdsFilter(featureIds));
+};
+
+/**
+ * Generates the filter for getting all the features with the featureIds
+ * @param featureIds - of type MongooseId
+ * @returns {Promise<ProductFeature>}
+ */
+function generateIdsFilter(featureIds) {
+  return {
+    _id: { $in: featureIds }
+  };
+}
+
 productFeaturesSchema.statics.featureFound = async function featureFound(featureLabel, count = 1, recursionDepth = 0) {
   return this.findOneAndUpdate(
     {


### PR DESCRIPTION
Sorts features by:
- Magnitude of: (min median index of feature - sum of lengths of features already in query).
- If equal, sorts by frequency

Note: The big diff in `backend/src/api/search.js` is the result of a small bug fix for parameter validation on line 23. This, in turn, made prettier decide to re-lint the entire file 🤷‍♂ 

Example query: `localhost:3001/api/search/autocomplete?q=&features=5e61d15fc6f9a9c480e8e134`

Completes: #31 