### PR TITLE
Can now search by feature ID. Parameter validator update

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,0 @@
-PORT=3001
-MONGO_URI=mongodb://localhost:27017/development
-SECRET=my_secret_secret

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,3 @@
+PORT=3001
+MONGO_URI=mongodb://localhost:27017/development
+SECRET=my_secret_secret

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1305,7 +1305,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -1323,11 +1324,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -1340,15 +1343,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -1451,7 +1457,8 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -1461,6 +1468,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -1473,17 +1481,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -1500,6 +1511,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -1580,7 +1592,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -1590,6 +1603,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -1665,7 +1679,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -1695,6 +1710,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -1712,6 +1728,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -1750,11 +1767,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },

--- a/backend/src/api/search.js
+++ b/backend/src/api/search.js
@@ -17,9 +17,9 @@ const searchController = require('../controllers/searchController');
 
   Args:
     q (str) (required): query key word
-    features (array containing Mongoose ObjectId's): comma-separated list of MongoObjectIDs
+    features (array containing Mongoose ObjectId's): IDs of features to search by
     category (str): query category
-    subcategories (array of strings): comma-separated list of subcategories
+    subcategories (array of strings): names of query subcategories
 
   Returns:
     array of all matching products
@@ -66,9 +66,9 @@ router.get(
 
   Args:
     q (str) (required): query key word
-    features (array containing Mongo ObjectId's): comma-separated list of Mongo Object id's (required).
+    features (array containing Mongo ObjectId's): IDs of features to search by
     category (str): query category
-    subcategories (array of strings): subcategories
+    subcategories (array of strings): query subcategories
 
   Returns:
     array of ProductFeature documents

--- a/backend/src/api/search.js
+++ b/backend/src/api/search.js
@@ -9,7 +9,7 @@ const searchController = require('../controllers/searchController');
   are searched if they are not provided as search params.
 
   Args:
-    q (str): query key word (required)
+    q (str): query key word (required) (product names must be separated by spaces)
     features (str): comma-separated list of MongoObjectIDs
     category (str): query category
     subcategories (str): comma-separated list of subcategories

--- a/backend/src/controllers/searchController.js
+++ b/backend/src/controllers/searchController.js
@@ -3,10 +3,20 @@ const { Product, ProductFeatures } = require('../database/models');
 
 const searchController = {};
 
+const DISTANCE_FROM_POSITION_MAX = 100000;
 const PAGE_SIZE = 15;
+const IS_ID_FIELD = 'IS_ID';
 const DIFF_FIELD = 'POSITION_DIFF';
 const FREQUENCY_FIELD = 'LOCAL_FREQUENCY';
 
+/**
+ * Gets a list of features by finding all products that match the query
+ * @param nameFilter - what to filter the productSearchableName by AND the featureName by
+ * @param filterCategory - what to filter the category by
+ * @param filterSubcategories - what to filter the subcategories by
+ * @param filterFeatureIds - a list of *required* feature id's that matching products need to have
+ * @returns {Promise<*|Aggregate>} a list of ProductFeature documents
+ */
 searchController.queryFeaturesByProducts = async (
   nameFilter,
   filterCategory,
@@ -35,25 +45,35 @@ searchController.queryFeaturesByProducts = async (
   return aggregateProductFeaturesFromProducts(filter, featureInQueryFilter, featureNameFilter, targetFeaturePosition);
 };
 
+/**
+ * Gets the total length of all features
+ * @param features - ProductFeature documents
+ * @returns the total length of all the product feature documents
+ */
 function getTotalLengthOfFeatures(features) {
   return features.map(feature => feature.name.length).reduce((left, right) => left + right, 0);
 }
 
-searchController.queryProducts = async (productNameFilter, filterCategory, filterSubcategories, filterFeatureIds) => {
+/**
+ * Queries Product documents and returns the matching Product documents
+ * @param productNames (array)  - must be within the product's "searchableName" (array) [OR'ED]
+ * @param filterCategory (can be null) - the category the product must be in
+ * @param filterSubcategories (array) (can be null) - the product's subcategories must fall under one of these subcategories [OR'ED]
+ * @param filterFeatureIds (array) - the required feature's the product must have. If empty array, then no required features [AND'ed]
+ * @returns {Promise<*>}
+ */
+searchController.queryProducts = async (productNames, filterCategory, filterSubcategories, filterFeatureIds) => {
   const filterFeatureMongooseIds = filterFeatureIds.map(ObjectId);
-  const filter = generateProductFilterWithRequiredFeatures(
-    productNameFilter,
-    filterCategory,
-    filterSubcategories,
-    filterFeatureMongooseIds
+  const filters = productNames.map(name =>
+    generateProductFilterWithRequiredFeatures(name, filterCategory, filterSubcategories, filterFeatureMongooseIds)
   );
   return Product.find()
-    .or(filter)
+    .or(filters)
     .limit(PAGE_SIZE);
 };
 
 /**
- *
+ * Generates a product filter with the parameters below
  * @param productNameFilter
  * @param filterCategory
  * @param filterSubcategories
@@ -70,6 +90,13 @@ function generateProductFilterWithRequiredFeatures(
   return addProductFeatureFilter(baseFilter, filterFeatureIds);
 }
 
+/**
+ * Generates a product filter with the parameters below
+ * @param productFilterString - searchable name must contain
+ * @param filterCategory (can be null) - the filter category (what to filter on)
+ * @param filterSubCategories (can be null) (can be empty) - what the subcategories must be
+ * @returns a product filter
+ */
 function generateBaseProductFilter(productFilterString, filterCategory, filterSubCategories) {
   const baseFilter = {
     searchableName: {
@@ -86,9 +113,10 @@ function generateBaseProductFilter(productFilterString, filterCategory, filterSu
 }
 
 /**
+ * Adds a ProductFEature filter to the inputted product feature
  * Note: No filter is applied if requireFeatureIds is empty (returns same number of products as the original filter)
- * @param filter
- * @param requiredFeatureIds - MUST be of type MongooseId
+ * @param filter - a product filter
+ * @param requiredFeatureIds (type MongooseID) - All the inputted features must exist on the returned Product document
  * @returns A Product filter with the added feature filter
  */
 function addProductFeatureFilter(filter, requiredFeatureIds) {
@@ -111,14 +139,13 @@ function generateBaseProductFeatureFilter(featureId) {
 }
 
 /**
- *
- * @param productFilter - what to filter the products on
- * @param productFeatureFilter - what to filter the features in the products on (not the entire feature documents;
- * the nested feature metadata
- * @param featureFilter - what to filter the entire feature documents on
+ * Aggregates all the ProductFeature documents from the matching products
+ * @param productFilter - what to filter the products on (what the product match on)
+ * @param productFeatureFilter - what to filter the features in the products on (not the entire feature documents; just the nested documents inside the Product document)
+ * @param featureFilter - what to filter the entire feature documents on  (what to filter the product features of matching product documents on)
  * @param targetPosition - the "target" position of the output features. Features will be returned in
- * order of how close they are to this target position
- * @returns {*|Aggregate}
+ * order of how close they are to this target position. If the feature has no position associated with it (such as an id), then target position = max possible integer
+ * @returns ProductFeature documents
  */
 function aggregateProductFeaturesFromProducts(productFilter, productFeatureFilter, featureFilter, targetPosition) {
   return Product.aggregate()
@@ -126,19 +153,21 @@ function aggregateProductFeaturesFromProducts(productFilter, productFeatureFilte
     .unwind('features')
     .replaceRoot('features')
     .match(productFeatureFilter)
+    .addFields(generateIsIdFieldForNestedProduct())
     .addFields({
       [DIFF_FIELD]: {
         $cond: {
           if: { $gte: ['$name.medianIndex', 0] },
           then: { $abs: { $subtract: ['$name.medianIndex', targetPosition] } },
-          else: 100000
+          else: DISTANCE_FROM_POSITION_MAX // if no median index == -1, then not in name. then assume a maximum distance away
         }
       }
     }) // calculate the diff from the target position
     .group({
       _id: '$productFeature',
       [DIFF_FIELD]: { $min: '$' + DIFF_FIELD },
-      [FREQUENCY_FIELD]: { $sum: 1 }
+      [FREQUENCY_FIELD]: { $sum: 1 },
+      [IS_ID_FIELD]: { $first: '$' + IS_ID_FIELD }
     }) // group matching product features. keep the one with the lowest delta
     .lookup({ from: 'productfeatures', localField: '_id', foreignField: '_id', as: 'productFeature' })
     .unwind('productFeature')
@@ -147,6 +176,18 @@ function aggregateProductFeaturesFromProducts(productFilter, productFeatureFilte
     .match(featureFilter)
     .sort({ [DIFF_FIELD]: 1, [FREQUENCY_FIELD]: -1 }) // sort by position diff
     .limit(PAGE_SIZE);
+}
+
+function generateIsIdFieldForNestedProduct() {
+  return {
+    [IS_ID_FIELD]: {
+      $cond: {
+        if: { $eq: ['$productId.count', 1] }, // if the feature has a count of 1 in the product id, then it's a product id
+        then: true,
+        else: false
+      }
+    }
+  };
 }
 
 module.exports = searchController;

--- a/backend/src/database/models/Product.js
+++ b/backend/src/database/models/Product.js
@@ -10,6 +10,7 @@ const featureDataSchema = {
 
 const productSchema = new mongoose.Schema({
   name: { type: String, required: true },
+  searchableName: { type: String, required: true },
   category: { type: String, required: true },
   subcategory: { type: String, required: true },
   productId: { type: String, required: true, unique: true },
@@ -17,12 +18,13 @@ const productSchema = new mongoose.Schema({
     {
       _id: { id: false },
       productFeature: { type: ObjectId, ref: 'ProductFeatures' },
-      name: featureDataSchema
+      name: featureDataSchema,
+      productId: featureDataSchema
     }
   ]
 });
 
-productSchema.statics.insertProduct = async function featureFound(product) {
+productSchema.statics.insertProduct = async function insertProduct(product) {
   return this.findOneAndUpdate(
     {
       productId: product.productId

--- a/backend/src/utilities/feature-extraction/csv-feature-extractor.js
+++ b/backend/src/utilities/feature-extraction/csv-feature-extractor.js
@@ -1,0 +1,82 @@
+const fs = require('fs');
+const Papa = require('papaparse');
+const { processProductObjectAndInsertIntoDB } = require('./process-product-object');
+
+const FILE_ENCODING = 'utf-8';
+const PRODUCT_OBJECT_KEYS = ['productId', 'name', 'category', 'subcategory'];
+const PRINT_UPDATE_MESSAGE_EVERY = 50;
+
+const DEFAULT_CSV_PRODUCT_MAPPING = {
+  ProductRef: 'productId',
+  ProductName: 'name',
+  'Category Name': 'category',
+  'Sub Category': 'subcategory'
+};
+
+function parseProductsFromCsvPath(filePath, mapping = DEFAULT_CSV_PRODUCT_MAPPING) {
+  const fileBuffer = fs.readFileSync(filePath, FILE_ENCODING);
+  return parseProductsFromCsv(fileBuffer, mapping);
+}
+
+function parseProductsFromCsv(fileBuffer, mapping) {
+  const result = Papa.parse(fileBuffer, {
+    header: true,
+    skipEmptyLines: true
+  });
+  const requiredFields = Object.keys(mapping);
+  if (!checkForExpectedFields(result.meta.fields, requiredFields)) {
+    throw new Error(
+      `The CSV was parsed and did not contain the expected ` +
+        `fields. Expected: ${requiredFields}. Found: ${result.fields}`
+    );
+  }
+  return processCsvResultObjects(result.data, mapping);
+}
+
+function checkForExpectedFields(resultFields, expectedFields) {
+  return expectedFields.every(field => resultFields.includes(field));
+}
+
+async function processCsvResultObjects(csvResultObjects, mapping) {
+  const validCsvObjects = csvResultObjects
+    .map(csvObject => csvObjectToProductObject(csvObject, mapping))
+    .filter(validateProductObject);
+  const productPromises = [];
+  for (let count = 0; count < validCsvObjects.length; count += 1) {
+    if ((count + 1) % PRINT_UPDATE_MESSAGE_EVERY === 0) {
+      const setNumber = parseInt((count + 1) / PRINT_UPDATE_MESSAGE_EVERY, 10);
+      console.log(`${setNumber}. Inserted ${PRINT_UPDATE_MESSAGE_EVERY} objects into database`);
+    }
+    const productPromise = processProductObjectAndInsertIntoDB(validCsvObjects[count]);
+    // eslint-disable-next-line no-await-in-loop
+    await productPromise; // temp solution to dupe key issue
+    productPromises.push(productPromise);
+  }
+  return Promise.all(productPromises);
+}
+
+function csvObjectToProductObject(csvObject, mapping) {
+  const productObject = {};
+  Object.entries(mapping).forEach(([csvKey, productKey]) => {
+    productObject[productKey] = csvObject[csvKey].toLowerCase();
+  });
+  return productObject;
+}
+
+function validateProductObject(productObject) {
+  return PRODUCT_OBJECT_KEYS.reduce((accumulator, expectedKey) => {
+    let currentObjectValid = true;
+    if (productObject[expectedKey] === undefined || productObject[expectedKey] instanceof String) {
+      console.log(
+        `WARNING: Missing key ${expectedKey} in ${JSON.stringify(
+          productObject
+        )}. It was filtered out from feature parsing.`
+      );
+      currentObjectValid = false;
+    }
+    return accumulator && currentObjectValid;
+  }, true);
+}
+module.exports = {
+  parseProductsFromCsvPath
+};

--- a/backend/src/utilities/index.js
+++ b/backend/src/utilities/index.js
@@ -1,6 +1,5 @@
-const { parseProductsFromCsvPath, processProductObjectAndInsertIntoDB } = require('./feature-extractor');
+const { parseProductsFromCsvPath } = require('./feature-extraction/csv-feature-extractor');
 
 module.exports = {
-  parseProductsFromCsvPath,
-  processProductObjectAndInsertIntoDB
+  parseProductsFromCsvPath
 };

--- a/frontend/src/components/ProductList.js
+++ b/frontend/src/components/ProductList.js
@@ -24,9 +24,9 @@ const useProductsQuery = () => {
   const debouncedQuery = useDebounce(query, 400);
 
   useEffect(() => {
-    const filteredFeatureIds = selectedFeatures.map(feature => feature._id).join(',');
+    const filteredFeatureIds = selectedFeatures.map(feature => feature._id);
 
-    getProductResults(debouncedQuery, filteredFeatureIds, category, selectedSubcats.join(','))
+    getProductResults(debouncedQuery, filteredFeatureIds, category, selectedSubcats)
       .then(results => {
         setProducts(results.data);
       })

--- a/frontend/src/components/QueryComponents.js
+++ b/frontend/src/components/QueryComponents.js
@@ -30,8 +30,8 @@ const useAutocomplete = () => {
   const debouncedQuery = useDebounce(query, 200); // debounce 200ms
 
   useEffect(() => {
-    const filterFeatureIds = selectedFeatures.map(feature => feature._id).join(',');
-    getAutocompleteResults(query, filterFeatureIds, category, selectedSubcats.join(','))
+    const filterFeatureIds = selectedFeatures.map(feature => feature._id);
+    getAutocompleteResults(query, filterFeatureIds, category, selectedSubcats)
       .then(results => {
         const filteredFeatures = results.data;
         console.log(filteredFeatures);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2211,11 +2211,6 @@
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
-    "papaparse": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.1.1.tgz",
-      "integrity": "sha512-KPkW4GNQxunmYTeJIjHFrvilcNuHBWrfgbyvmagEmfGOA4hnP1WIkPbv4yABhj1Nam3as4w+7MBiI27BntwqVg=="
-    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",


### PR DESCRIPTION
**Product ID's are now queryable features:**
All product id feature names are prefixed with a `#`.

*Note,* product ID's have "#" in the string names, which means when sending the request to the API for autocomplete, you should encode the URL with the various escape sequences for special characters. You need to do this because the user might be trying to query with the "#" in the id name. 
`# -> %23`

For instance,
Instead of `localhost:3001/api/search/autocomplete?q=#7222&features=`
you need to do
`localhost:3001/api/search/autocomplete?q=%237222&features=`

**Parameter validation changes:**
- All end points now use express-validator for parameter validation
- Array parameters should be given as standard array query parameters: `?features={{id 1}}&features={{id 2}}&features={{id 3}}`

**Method Documentation Update:**
- Methods now have more up-to-date comments

**Future plans:**
- More code refactor of feature-extraction (dedicated classes)
- Unit tests

Completes #39