### PR TITLE
Fix for Product Search

### DIFF
--- a/backend/src/controllers/searchController.js
+++ b/backend/src/controllers/searchController.js
@@ -63,7 +63,7 @@ function getTotalLengthOfFeatures(features) {
 searchController.queryProducts = async (productName, filterCategory, filterSubcategories, filterFeatureIds) => {
   const filter = generateProductFilterWithRequiredFeatures(
     productName,
-    productName,
+    filterCategory,
     filterSubcategories,
     filterFeatureIds
   );


### PR DESCRIPTION
Currently, product search is not working because the productName is being used to generate the filter for both "productName" and "category" when querying product documents. This fixes the typo (appeared sometime during refactoring)

Example: `localhost:3001/api/search?q=misc`